### PR TITLE
Secrets cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,5 +35,6 @@ workflows:
   build:
     jobs:
       - linux-build:
+          context: orb-publishing
           filters:
             <<: *current_filters


### PR DESCRIPTION
CircleCI secret cleanup. use contexts for env vars, rather than project-specific env vars. Once this is merged, I will delete all of the project-specific env vars.